### PR TITLE
Task 2 build a feature

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,10 +7,13 @@ import Launch from "./launch";
 import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
+import FavouritesDrawer from "./favourites";
+import { FavouritesContextProvider } from "../store/favourites-context";
 
 export default function App() {
   return (
     <div>
+    <FavouritesContextProvider>
       <NavBar />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -19,6 +22,7 @@ export default function App() {
         <Route path="/launch-pads" element={<LaunchPads />} />
         <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
       </Routes>
+    </FavouritesContextProvider>
     </div>
   );
 }
@@ -42,6 +46,7 @@ function NavBar() {
       >
         ¡SPACE·R0CKETS!
       </Text>
+      <FavouritesDrawer/>
     </Flex>
   );
 }

--- a/src/components/favourite-button.js
+++ b/src/components/favourite-button.js
@@ -1,0 +1,41 @@
+import React, { useContext } from 'react';
+import { IconButton } from '@chakra-ui/core';
+import { Star } from "react-feather";
+import FavouritesContext from '../store/favourites-context';
+
+export const TYPES = {
+  LAUNCH: "LAUNCH",
+  LAUNCHPAD: "LAUNCHPAD"
+}
+
+export default function FavouriteButton({type, item}) {
+  const { favourites, favouriteLaunch, unfavouriteLaunch, favouriteLaunchPad, unfavouriteLaunchPad } = useContext(FavouritesContext);
+
+  const isFavourite = 
+    favourites.launches.find((launch) => launch.flight_number === item.flight_number) || 
+    favourites.launchPads.find((launchPad) => launchPad.site_id === item.site_id) 
+    ? true : false;
+
+  function handleClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (type === TYPES.LAUNCH) {
+      isFavourite ? unfavouriteLaunch(item) : favouriteLaunch(item);
+    }
+    if (type === TYPES.LAUNCHPAD) {
+      isFavourite ? unfavouriteLaunchPad(item) : favouriteLaunchPad(item);
+    }
+}
+
+  return (
+    <IconButton
+      onClick={handleClick}
+      as={Star}
+      size="md"
+      p={2}
+      cursor="pointer"
+      aria-label={isFavourite ? "Unfavourite" : "Favourite"}
+      fill={isFavourite ? "#FFE338" : "none"}
+    />
+  )
+}

--- a/src/components/favourite-button.test.js
+++ b/src/components/favourite-button.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import withWrapperComponents from './withWrapperComponents';
+
+import FavouriteButton, { TYPES } from './favourite-button';
+
+const launchProps = {
+  type: TYPES.LAUNCH,
+  item: { "flight_number": 108 }
+}
+
+const launchPadProps = {
+  type: TYPES.LAUNCHPAD,
+  item: { "site_id": 108}
+}
+
+describe('FavouriteButton', () => {
+  test('Favourite button launch', async () => {
+    const { getByLabelText } = render(withWrapperComponents(<FavouriteButton {...launchProps}/>));
+    const favouriteButton = getByLabelText('Favourite');
+    userEvent.click(favouriteButton);
+    await waitFor(() => getByLabelText('Unfavourite'));
+    userEvent.click(favouriteButton);
+    await waitFor(() => getByLabelText('Favourite'));
+  })
+
+  test('Favourite button launch pad', async () => {
+    const { getByLabelText } = render(withWrapperComponents(<FavouriteButton {...launchPadProps}/>));
+    const favouriteButton = getByLabelText('Favourite');
+    userEvent.click(favouriteButton);
+    await waitFor(() => getByLabelText('Unfavourite'));
+    userEvent.click(favouriteButton);
+    await waitFor(() => getByLabelText('Favourite'));
+  })
+
+  test('Set correctly for an existing favourite', () => {
+    const favourites = { 
+      launches: [
+        {
+          "flight_number": 108,
+          "mission_name": "Sentinel-6 Michael Freilich",
+        }
+      ],
+      launchPads: []
+    }
+    const { getByLabelText } = render(withWrapperComponents(<FavouriteButton {...launchProps}/>, favourites));
+    getByLabelText('Unfavourite');
+  })
+})

--- a/src/components/favourites.js
+++ b/src/components/favourites.js
@@ -1,0 +1,69 @@
+import React, { useContext } from "react";
+import {
+    useDisclosure,
+    Drawer,
+    DrawerBody,
+    DrawerHeader,
+    DrawerOverlay,
+    DrawerContent,
+    DrawerCloseButton,
+    Button,
+    Heading,
+    SimpleGrid,
+    Divider
+} from '@chakra-ui/core';
+import { LaunchItem } from "./launches";
+import { LaunchPadItem } from "./launch-pads";
+import FavouritesContext from "../store/favourites-context";
+
+export default function FavouritesDrawer() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { favourites } = useContext(FavouritesContext);
+
+  return (
+    <>
+      <Button color="black" onClick={onOpen}>
+        Favourites
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        scrollBehavior="inside"
+        size="sm"
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Favourites</DrawerHeader>
+          <DrawerBody pb={6}>
+            <FavouritesSection 
+              name="Launches" 
+              data={favourites.launches}
+              mapFunction={launch => <LaunchItem key={launch.flight_number} launch={launch}/>}
+            />
+            <Divider my={8} />
+            <FavouritesSection 
+              name="Launch Pads" 
+              data={favourites.launchPads}
+              mapFunction={launchPad => <LaunchPadItem key={launchPad.site_id} launchPad={launchPad}/>}
+            />
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+}
+
+function FavouritesSection({name, data, mapFunction}) {
+  return (
+    <>
+      <SimpleGrid spacing="4">
+        <Heading as='h3' size='sm'>
+          {name} ({data.length})
+        </Heading>
+        {data.map(item => mapFunction(item))}
+      </SimpleGrid>
+    </>
+  )
+}

--- a/src/components/favourites.test.js
+++ b/src/components/favourites.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import withWrapperComponents from './withWrapperComponents';
+
+import FavouritesDrawer from './favourites';
+
+const favourites = { 
+  launches: [
+    {
+      "flight_number": 108,
+      "mission_name": "Sentinel-6 Michael Freilich",
+      "launch_date_unix": 1605979020,
+      "launch_date_utc": "2020-11-21T17:17:00.000Z",
+      "launch_date_local": "2020-11-21T09:17:00-08:00",
+      "rocket": {
+        "rocket_id": "falcon9",
+        "rocket_name": "Falcon 9",
+        "rocket_type": "FT",
+      },
+      "launch_site": {
+        "site_id": "vafb_slc_4e",
+        "site_name": "VAFB SLC 4E",
+        "site_name_long": "Vandenberg Air Force Base Space Launch Complex 4E"
+      },
+      "launch_success": true,
+      "links": {
+        "mission_patch": null,
+        "mission_patch_small": null,
+        "flickr_images": [
+          "https://live.staticflickr.com/65535/50630802488_8cc373728e_o.jpg",
+        ]
+      },
+    },
+    {
+      "flight_number": 107,
+      "mission_name": "Crew-1",
+      "launch_date_utc": "2020-11-16T00:27:00.000Z",
+      "launch_date_local": "2020-11-15T19:27:00-05:00",
+      
+      "rocket": {
+        "rocket_id": "falcon9",
+        "rocket_name": "Falcon 9",
+        "rocket_type": "FT",
+      },
+      "launch_site": {
+        "site_id": "ksc_lc_39a",
+        "site_name": "KSC LC 39A",
+        "site_name_long": "Kennedy Space Center Historic Launch Complex 39A"
+      },
+      "launch_success": true,
+      "links": {
+        "mission_patch": "https://i.imgur.com/t5R4BAQ.png",
+        "mission_patch_small": "https://i.imgur.com/BzaSAnx.png",
+        "flickr_images": [
+          "https://live.staticflickr.com/65535/50618376646_8f52c31fc4_o.jpg"
+        ]
+      }
+    }
+  ],
+  launchPads: [
+    {
+      "id": 1,
+      "name": "Kwajalein Atoll",
+      "status": "retired",
+      "vehicles_launched": [
+        "Falcon 1"
+      ],
+      "attempted_launches": 5,
+      "successful_launches": 2,
+      "site_id": "kwajalein_atoll",
+      "site_name_long": "Kwajalein Atoll Omelek Island"
+    },
+    {
+      "id": 5,
+      "name": "VAFB SLC 3W",
+      "status": "retired",
+      "vehicles_launched": [
+        "Falcon 1"
+      ],
+      "attempted_launches": 0,
+      "successful_launches": 0,
+      "site_id": "vafb_slc_3w",
+      "site_name_long": "Vandenberg Air Force Base Space Launch Complex 3W"
+    }
+  ]
+}
+
+describe('FavouritesDrawer', () => {
+  test('Should display favourites in drawer', async () => {
+    const { getByRole, getByText } = render(withWrapperComponents(<FavouritesDrawer/>, favourites));
+    userEvent.click(getByRole("button"));
+    await waitFor(() => getByText(favourites.launches[0].mission_name));
+    getByText(favourites.launches[1].mission_name);
+    getByText(favourites.launchPads[0].name);
+    getByText(favourites.launchPads[1].name);
+  })
+
+  test('Clicking on favourite in drawer will remove', async () => {
+    const { getByRole, getByText, queryByText } = render(withWrapperComponents(<FavouritesDrawer/>, favourites));
+    userEvent.click(getByRole("button"));
+    await waitFor(() => getByText(favourites.launches[0].mission_name));
+    const launchItem = getByText(favourites.launches[0].mission_name).closest('a');
+    userEvent.click(within(launchItem).getByLabelText("Unfavourite"));
+    await waitFor(() => expect(queryByText(favourites.launches[0].mission_name)).toBeNull());
+  })
+})

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -21,6 +21,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import { LaunchItem } from "./launches";
+import FavouriteButton, { TYPES } from "./favourite-button";
 
 export default function LaunchPad() {
   let { launchPadId } = useParams();
@@ -91,7 +92,7 @@ function Header({ launchPad }) {
       >
         {launchPad.site_name_long}
       </Heading>
-      <Stack isInline spacing="3">
+      <Stack isInline spacing="3" align="center">
         <Badge variantColor="purple" fontSize={["sm", "md"]}>
           {launchPad.successful_launches}/{launchPad.attempted_launches}{" "}
           successful
@@ -105,6 +106,7 @@ function Header({ launchPad }) {
             Retired
           </Badge>
         )}
+        <FavouriteButton type={TYPES.LAUNCHPAD} item={launchPad}/>
       </Stack>
     </Flex>
   );

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
+import FavouriteButton, { TYPES } from "./favourite-button";
 import { useSpaceXPaginated } from "../utils/use-space-x";
 
 const PAGE_SIZE = 12;
@@ -41,7 +42,7 @@ export default function LaunchPads() {
   );
 }
 
-function LaunchPadItem({ launchPad }) {
+export function LaunchPadItem({ launchPad }) {
   return (
     <Box
       as={Link}
@@ -53,27 +54,30 @@ function LaunchPadItem({ launchPad }) {
       position="relative"
     >
       <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launchPad.status === "active" ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Active
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Retired
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launchPad.attempted_launches} attempted &bull;{" "}
-            {launchPad.successful_launches} succeeded
+        <Box d="flex" alignItems="center" justifyContent="space-between">
+          <Box>
+            {launchPad.status === "active" ? (
+              <Badge px="2" variant="solid" variantColor="green">
+                Active
+              </Badge>
+            ) : (
+              <Badge px="2" variant="solid" variantColor="red">
+                Retired
+              </Badge>
+            )}
+            <Box
+              color="gray.500"
+              fontWeight="semibold"
+              letterSpacing="wide"
+              fontSize="xs"
+              textTransform="uppercase"
+              mt="1"
+            >
+              {launchPad.attempted_launches} attempted &bull;{" "}
+              {launchPad.successful_launches} succeeded
+            </Box>
           </Box>
+          <FavouriteButton type={TYPES.LAUNCHPAD} item={launchPad}/>
         </Box>
 
         <Box

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -26,6 +26,7 @@ import { useSpaceX } from "../utils/use-space-x";
 import { formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
+import FavouriteButton, { TYPES } from "./favourite-button";
 
 export default function Launch() {
   let { launchId } = useParams();
@@ -96,7 +97,7 @@ function Header({ launch }) {
       >
         {launch.mission_name}
       </Heading>
-      <Stack isInline spacing="3">
+      <Stack isInline spacing="3" align="center">
         <Badge variantColor="purple" fontSize={["xs", "md"]}>
           #{launch.flight_number}
         </Badge>
@@ -109,6 +110,7 @@ function Header({ launch }) {
             Failed
           </Badge>
         )}
+        <FavouriteButton type={TYPES.LAUNCH} item={launch}/>
       </Stack>
     </Flex>
   );

--- a/src/components/launch.test.js
+++ b/src/components/launch.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Router } from 'react-router-dom';
-import { createMemoryHistory } from 'history';
 import { formatDateTime } from '../utils/format-date';
+import withWrapperComponents from './withWrapperComponents';
 
 import  { TimeAndLocation }  from './launch';
 
@@ -19,28 +18,18 @@ const defaultProps = {
   }
 }
 
-const setupComponent = () => {
-  const history = createMemoryHistory();
-  return (
-    <Router history={history}>
-      <TimeAndLocation {...defaultProps}/>
-    </Router>);
-};
-
 const originalTime = formatDateTime(defaultProps.launch.launch_date_local, true);
 const localtime = `Your local time: ${formatDateTime(defaultProps.launch.launch_date_local)}`;
 
 describe('TimeAndLocation', () => {
   test('Should display only original timezone initially', () => {
-    const component = setupComponent();
-    const { getByText, queryByText } = render(component);
+    const { getByText, queryByText } = render(withWrapperComponents(<TimeAndLocation {...defaultProps}/>));
     getByText(originalTime);
     expect(queryByText(localtime)).toBeNull();
   })
 
   test('Should display local timezone on hover', async () => {
-    const component = setupComponent();
-    const { getByText } = render(component);
+    const { getByText } = render(withWrapperComponents(<TimeAndLocation {...defaultProps}/>));
     const date = getByText(originalTime);
     userEvent.hover(date);
     await waitFor(() => getByText(localtime));

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -8,6 +8,7 @@ import { formatDate } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 import LoadMoreButton from "./load-more-button";
+import FavouriteButton, { TYPES } from "./favourite-button";
 
 const PAGE_SIZE = 12;
 
@@ -79,26 +80,29 @@ export function LaunchItem({ launch }) {
       />
 
       <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launch.launch_success ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Successful
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Failed
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
+        <Box d="flex" alignItems="center" justifyContent="space-between">
+          <Box>
+            {launch.launch_success ? (
+              <Badge px="2" variant="solid" variantColor="green">
+                Successful
+              </Badge>
+            ) : (
+              <Badge px="2" variant="solid" variantColor="red">
+                Failed
+              </Badge>
+            )}
+            <Box
+              color="gray.500"
+              fontWeight="semibold"
+              letterSpacing="wide"
+              fontSize="xs"
+              textTransform="uppercase"
+              mt="1"
+            >
+              {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
+            </Box>
           </Box>
+          <FavouriteButton type={TYPES.LAUNCH} item={launch}/>
         </Box>
 
         <Box

--- a/src/components/withWrapperComponents.js
+++ b/src/components/withWrapperComponents.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { ThemeProvider, CSSReset } from "@chakra-ui/core";
+import { FavouritesContextProvider } from '../store/favourites-context';
+
+const withWrapperComponents = (Component, initialFavourites) => (
+  <Router history={createMemoryHistory()}>
+    <ThemeProvider>
+      <CSSReset/>
+      <FavouritesContextProvider initialFaves={initialFavourites}>
+        {Component}
+      </FavouritesContextProvider>
+    </ThemeProvider>
+  </Router>
+);
+
+export default withWrapperComponents;

--- a/src/store/favourites-context.js
+++ b/src/store/favourites-context.js
@@ -1,0 +1,101 @@
+import React, { useEffect, useReducer } from "react";
+
+const initialFavourites = 
+  localStorage.getItem("favourites")
+  ? JSON.parse(localStorage.getItem("favourites"))
+  : [];
+
+const FavouritesContext = React.createContext({
+  favourites: initialFavourites,
+  favouriteLaunch: () => {},
+  unfavouriteLaunch: () => {},
+  favouriteLaunchPad: () => {},
+  unfavouriteLaunchPad: () => {}
+})
+
+const ACTIONS = {
+  FAVOURITE_LAUNCH: "FAVOURITE_LAUNCH",
+  UNFAVOURITE_LAUNCH: 'UNFAVOURITE_LAUNCH',
+  FAVOURITE_LAUNCHPAD: "FAVOURITE_LAUNCHPAD",
+  UNFAVOURITE_LAUNCHPAD: 'UNFAVOURITE_LAUNCHPAD',
+};
+
+const favouritesReducer = (state, action) => {
+  switch (action.type) {
+    case ACTIONS.FAVOURITE_LAUNCH: {
+      return {
+        launches: [...state.launches, action.data], 
+        launchPads: state.launchPads
+      }
+    }
+    case ACTIONS.UNFAVOURITE_LAUNCH: {
+      return {
+        launches: state.launches.filter(launch => launch.flight_number !== action.data.flight_number), 
+        launchPads: state.launchPads
+      }
+    }
+    case ACTIONS.FAVOURITE_LAUNCHPAD: {
+      return {
+        launches: state.launches, 
+        launchPads: [...state.launchPads, action.data]
+      }
+    }
+    case ACTIONS.UNFAVOURITE_LAUNCHPAD: {
+      return {
+        launches: state.launches, 
+        launchPads: state.launchPads.filter(launchPad => launchPad.site_id !== action.data.site_id)
+      }
+    }
+    default:
+      return state;
+  }
+};
+
+export const FavouritesContextProvider = ({ children }) => {
+  const [favourites, dispatchFavourites] = useReducer(favouritesReducer, initialFavourites)
+
+  useEffect(() => {
+    localStorage.setItem(
+      "favourites",
+      JSON.stringify(favourites)
+    );
+  }, [favourites]);
+
+  const favouriteLaunch = (launch) => {
+    dispatchFavourites ({
+      type: ACTIONS.FAVOURITE_LAUNCH,
+      data: launch,
+    });
+  }
+
+  const unfavouriteLaunch = (launch) => {
+    dispatchFavourites ({
+      type: ACTIONS.UNFAVOURITE_LAUNCH,
+      data: launch,
+    });
+  }
+
+  const favouriteLaunchPad = (launchPad) => {
+    dispatchFavourites ({
+      type: ACTIONS.FAVOURITE_LAUNCHPAD,
+      data: launchPad,
+    });
+  }
+
+  const unfavouriteLaunchPad = (launchPad) => {
+    dispatchFavourites ({
+      type: ACTIONS.UNFAVOURITE_LAUNCHPAD,
+      data: launchPad,
+    });
+  }
+
+  return (
+    <FavouritesContext.Provider 
+      value={{ favourites, favouriteLaunch, unfavouriteLaunch, favouriteLaunchPad, unfavouriteLaunchPad }}
+    >
+      { children }
+    </FavouritesContext.Provider>
+  )
+}
+
+export default FavouritesContext;

--- a/src/store/favourites-context.js
+++ b/src/store/favourites-context.js
@@ -3,7 +3,7 @@ import React, { useEffect, useReducer } from "react";
 const initialFavourites = 
   localStorage.getItem("favourites")
   ? JSON.parse(localStorage.getItem("favourites"))
-  : [];
+  : {launches: [], launchPads: []};
 
 const FavouritesContext = React.createContext({
   favourites: initialFavourites,

--- a/src/store/favourites-context.js
+++ b/src/store/favourites-context.js
@@ -51,8 +51,8 @@ const favouritesReducer = (state, action) => {
   }
 };
 
-export const FavouritesContextProvider = ({ children }) => {
-  const [favourites, dispatchFavourites] = useReducer(favouritesReducer, initialFavourites)
+export const FavouritesContextProvider = ({ children, initialFaves = initialFavourites }) => {
+  const [favourites, dispatchFavourites] = useReducer(favouritesReducer, initialFaves)
 
   useEffect(() => {
     localStorage.setItem(


### PR DESCRIPTION
### FEATURE: Add favourites functionality for launches / launch pads. Display favourites in a drawer.
#### Resolution:
* Implemented FavouritesContext/Reducer to handle favourites across components
* Favourites Drawer added, reachable from Navigation bar
* Favourite button added to launches / launch pads lists and details pages
* Used ChakraUI components for Drawer / Favourite Button
* Used existing Launch / LaunchPad items to display in Favourites Drawer
* Favourites stored in localStorage
* Added some unit tests for favourites functionality
* Added wrapper for unit test components to avoid repetition

#### Further steps:
* Implement comprehensive unit test suite (e.g. testing favourites functionality from within launches / launch pads) - descoped full suite due to time
* Update to only store the ids of favourites (rather than whole launch/launch pad object) & get full data from api call
* Possible improvements to UI/UX:
~ when unfavouriting from drawer, implement short delay before removing from list in case accidentally unfavourited (to allow them to re-click the favourite button)
~ create condensed launch cards for favourites drawer, as current ones a bit large
~ make favourites drawer sections collapsible to reduce scrolling